### PR TITLE
CFT MariaDB - initial import from internal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
+# terraform-google-redis
+=======
 # terraform-google-mariadb
+>>>>>>> Initial commit
 
 This module was generated from [terraform-google-module-template](https://github.com/terraform-google-modules/terraform-google-module-template/), which by default generates a module that simply creates a GCS bucket. As the module develops, this README should be updated.
 
@@ -11,8 +15,13 @@ The resources/services/activations/deletions that this module will create/trigge
 Basic usage of this module is as follows:
 
 ```hcl
+<<<<<<< HEAD
+module "redis" {
+  source  = "terraform-google-modules/redis/google"
+=======
 module "mariadb" {
   source  = "terraform-google-modules/mariadb/google"
+>>>>>>> Initial commit
   version = "~> 0.1"
 
   project_id  = "<PROJECT ID>"

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -13,12 +13,9 @@
 # limitations under the License.
 
 steps:
-- name: 'gcr.io/cloud-foundation-cicd/cft/developer-tools:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+- name: 'gcr.io/cloud-foundation-cicd/cft/developer-tools:0.1.0'
   id: 'lint'
   args: ['/usr/local/bin/test_lint.sh']
 tags:
 - 'ci'
 - 'lint'
-substitutions:
-  _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.1.0'

--- a/examples/mariadb/README.md
+++ b/examples/mariadb/README.md
@@ -1,6 +1,10 @@
 # Simple Example
 
+<<<<<<< HEAD
+This example illustrates how to use the `redis` module.
+=======
 This example illustrates how to use the `mariadb` module.
+>>>>>>> Initial commit
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs

--- a/examples/mariadb/main.tf
+++ b/examples/mariadb/main.tf
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+provider "google-beta" {
+  version = "~> 2.0"
+}
+
+module "admin" {
+  source          = "../../modules/admin"
+  project_id      = var.project_id
+  network_project = var.network_project
+  network         = var.network
+  service_account = var.service_account
+  bucket_name     = var.bucket_name
+  client_ip_range = var.client_ip_range
+}
+
+module "health_check" {
+  source            = "../../modules/health_check"
+  project_id        = var.project_id
+  health_check_name = var.health_check_name
+}
+
+module "mariadb" {
+  source             = "../../modules/mariadb"
+  cluster_name       = var.cluster_name
+  create_time        = "${var.create_time == "" ? timestamp() : var.create_time}"
+  databases          = var.databases
+  project_id         = var.project_id
+  region             = var.region
+  zone               = var.zone
+  garb_zone          = var.garb_zone
+  garb_instance_type = var.instance_type
+  garb_region        = var.garb_region
+  garb_subnetwork    = var.garb_subnetwork
+  network_project    = var.network_project
+  subnetwork         = var.subnetwork
+  health_check_uri   = module.health_check.health_check_uri
+  service_account    = var.service_account
+  bucket_name        = module.admin.bucket_name
+  vm_image           = var.vm_image
+  instance_type      = var.instance_type
+  disk_size_gb       = var.disk_size_gb
+  disk_type          = var.disk_type
+  client_ip_range    = var.client_ip_range
+  pass               = var.pass
+  statspass          = var.statspass
+  replpass           = var.replpass
+  instance_count     = var.instance_count
+  template_version   = var.template_version
+}

--- a/examples/mariadb/outputs.tf
+++ b/examples/mariadb/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,5 +16,5 @@
 
 output "bucket_name" {
   description = "The name of the bucket."
-  value       = module.mariadb.bucket_name
+  value       = module.admin.bucket_name
 }

--- a/examples/mariadb/terraform.tfvars.example
+++ b/examples/mariadb/terraform.tfvars.example
@@ -1,0 +1,39 @@
+project_id = "myproject"
+bucket_name = "mybucket"
+cluster_name = "cluster1"
+region = [
+  "us-east1",
+  "us-east1",
+  "us-east1",
+  "us-east1",
+]
+zone = [
+  "us-east1-b",
+  "us-east1-b",
+  "us-east1-b",
+  "us-east1-b",
+]
+subnetwork = [
+  "default",
+  "default",
+  "default",
+  "default",
+]
+vm_image = "debian-cloud/debian-9"
+garb_instance_type = "f1-micro"
+garb_zone = "us-east1-a"
+garb_region = "us-east1"
+garb_subnetwork = "default"
+network_project = "default"
+network = "default"
+service_account = "mariadb"
+instance_type = "g1-small"
+client_ip_range = "10.0.0.0/8"
+pass = "changeit"
+replpass = "changeit"
+statspass = "changeit"
+disk_size_gb = 32
+disk_type = "pd-standard"
+health_check_name = "mariadb"
+databases = "db"
+template_version = "v1"

--- a/examples/mariadb/variables.tf
+++ b/examples/mariadb/variables.tf
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The ID of the project in which to provision resources."
+  type        = string
+}
+
+variable "bucket_name" {
+  description = "The name of the bucket to create."
+  type        = string
+}
+
+variable "cluster_name" {
+  type = string
+}
+
+variable "create_time" {
+  description = "Creation time formatted as 2018-01-02T23:12:01Z used to allow cluster bootstrap."
+  type        = string
+  default     = ""
+}
+
+variable "instance_count" {
+  type    = number
+  default = 4
+}
+
+variable "region" {
+  type = list(string)
+}
+
+variable "zone" {
+  type = list(string)
+}
+
+variable "subnetwork" {
+  type = list(string)
+}
+
+variable "vm_image" { default = "debian-cloud/debian-9" }
+variable "garb_instance_type" { default = "n1-standard-1" }
+variable "garb_zone" { type = string }
+variable "garb_region" { type = string }
+variable "garb_subnetwork" { default = "default" }
+variable "network_project" { type = string }
+variable "network" { default = "default" }
+variable "service_account" { type = string }
+variable "instance_type" { type = string }
+variable "client_ip_range" { default = "10.0.0.0/8" }
+variable "pass" { type = string }
+variable "replpass" { type = string }
+variable "statspass" { type = string }
+variable "disk_size_gb" { type = number }
+variable "disk_type" { default = "pd-standard" }
+variable "health_check_name" { type = string }
+
+variable "databases" {
+  description = "Space separated list of databases to be created."
+  type        = string
+}
+
+variable "template_version" {
+  description = "A version identifier included in instance template names."
+  type        = string
+  default     = "v1"
+}

--- a/examples/mariadb/versions.tf
+++ b/examples/mariadb/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.0"
-}
-
-resource "google_storage_bucket" "main" {
-  project = var.project_id
-  name    = var.bucket_name
+  required_version = ">= 0.12"
 }

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,18 +26,18 @@ platforms:
   - name: default
 
 suites:
-  - name: simple_example
+  - name: mariadb
     driver:
-      root_module_directory: test/fixtures/simple_example/
+      root_module_directory: test/fixtures/mariadb/
     verifier:
       color: false
       systems:
-        - name: simple_example local
+        - name: mariadb local
           backend: local
           controls:
             - gcloud
             - gsutil
-        - name: simple_example gcp
+        - name: mariadb gcp
           backend: gcp
           controls:
             - gcp

--- a/modules/admin/main.tf
+++ b/modules/admin/main.tf
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = "~> 0.12.0"
+}
+
+data "google_compute_network" "network" {
+  project = var.project_id
+  name    = var.network
+}
+
+resource "google_service_account" "default" {
+  project      = var.project_id
+  account_id   = var.service_account
+  display_name = var.service_account
+}
+
+resource "google_project_iam_member" "logs" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.default.email}"
+}
+
+resource "google_project_iam_member" "metrics" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.default.email}"
+}
+
+resource "google_compute_firewall" "mariadb" {
+  project                 = var.network_project
+  network                 = var.network
+  name                    = "mariadb"
+  target_service_accounts = [google_service_account.default.email]
+  allow {
+    protocol = "tcp"
+    ports    = ["3306"]
+  }
+  source_ranges = [var.client_ip_range, "35.191.0.0/16", "130.211.0.0/22"]
+}
+
+resource "google_compute_firewall" "cluster" {
+  project = var.network_project
+  name    = "mariadb-cluster-${var.service_account}"
+  network = var.network
+  allow {
+    protocol = "tcp"
+    ports    = ["3306", "4567", "4444"]
+  }
+  source_service_accounts = [google_service_account.default.email]
+  target_service_accounts = [google_service_account.default.email]
+}
+
+resource "google_storage_bucket" "config" {
+  project       = var.project_id
+  name          = var.bucket_name
+  storage_class = "MULTI_REGIONAL"
+  depends_on    = [null_resource.api]
+}
+
+resource "google_storage_bucket_iam_binding" "config" {
+  bucket  = google_storage_bucket.config.name
+  role    = "roles/storage.objectViewer"
+  members = ["serviceAccount:${google_service_account.default.email}"]
+}
+
+# Needed for CI to wait for Cloud Storage API to become ready
+resource "null_resource" "api" {
+  provisioner "local-exec" {
+    command = <<EOF
+for i in {1..6}; do
+  if gcloud services list --project="${var.project_id}" | grep -q "storage-api.googleapis.com"; then
+    exit 0
+  fi
+  echo "Waiting for storage-api.googleapis.com to be enabled"
+  sleep 10
+done
+
+echo "storage-api.googleapis.com was not enabled after 60s"
+exit 1
+EOF
+  }
+}

--- a/modules/admin/outputs.tf
+++ b/modules/admin/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
-terraform {
-  required_version = ">= 0.12"
+output "bucket_name" {
+  description = "The name of the bucket."
+  value       = google_storage_bucket.config.name
 }

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,19 @@
  * limitations under the License.
  */
 
-output "bucket_name" {
-  description = "The name of the bucket."
-  value       = module.example.bucket_name
+variable "project_id" {
+  description = "The ID of the project in which to provision resources."
+  type        = string
 }
 
-output "project_id" {
-  description = "The ID of the project in which resources are provisioned."
-  value       = var.project_id
+variable "bucket_name" {
+  description = "The name of the bucket to create."
+  type        = string
 }
+
+variable "network_project" { default = "" }
+variable "network" { default = "" }
+variable "subnetwork" { default = "" }
+variable "service_account" { default = "" }
+variable "client_ip_range" { default = "" }
+variable "health_check_name" { default = "" }

--- a/modules/admin/versions.tf
+++ b/modules/admin/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,6 @@
  * limitations under the License.
  */
 
-provider "google" {
-  version = "~> 2.0"
-}
-
-module "mariadb" {
-  source = "../.."
-
-  project_id  = var.project_id
-  bucket_name = var.bucket_name
+terraform {
+  required_version = ">= 0.12"
 }

--- a/modules/health_check/main.tf
+++ b/modules/health_check/main.tf
@@ -14,20 +14,19 @@
  * limitations under the License.
  */
 
-module "project" {
-  source  = "terraform-google-modules/project-factory/google"
-  version = "~> 3.0"
+terraform {
+  required_version = "~> 0.12.0"
+}
 
-  name              = "ci-mariadb"
-  random_project_id = "true"
-  org_id            = var.org_id
-  folder_id         = var.folder_id
-  billing_account   = var.billing_account
+resource "google_compute_health_check" "mariadb" {
+  project             = var.project_id
+  name                = var.health_check_name
+  timeout_sec         = 30
+  check_interval_sec  = 60
+  healthy_threshold   = 1
+  unhealthy_threshold = 4
 
-  activate_apis = [
-    "cloudresourcemanager.googleapis.com",
-    "storage-api.googleapis.com",
-    "serviceusage.googleapis.com",
-    "iam.googleapis.com"
-  ]
+  tcp_health_check {
+    port = "3306"
+  }
 }

--- a/modules/health_check/outputs.tf
+++ b/modules/health_check/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
-terraform {
-  required_version = ">= 0.12"
+output "health_check_uri" {
+  description = "The URI of the health check."
+  value       = google_compute_health_check.mariadb.self_link
 }

--- a/modules/health_check/variables.tf
+++ b/modules/health_check/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,3 +18,5 @@ variable "project_id" {
   description = "The ID of the project in which to provision resources."
   type        = string
 }
+
+variable "health_check_name" { default = "" }

--- a/modules/health_check/versions.tf
+++ b/modules/health_check/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-variable "project_id" {
-  description = "The project ID to deploy to"
-}
-
-variable "bucket_name" {
-  description = "The name of the bucket to create"
+terraform {
+  required_version = ">= 0.12"
 }

--- a/modules/mariadb/main.tf
+++ b/modules/mariadb/main.tf
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = "~> 0.12.0"
+}
+
+resource "google_compute_address" "mariadb" {
+  count        = var.instance_count
+  project      = var.project_id
+  name         = format("mariadb-${var.cluster_name}-%03d", count.index)
+  subnetwork   = var.subnetwork[count.index]
+  address_type = "INTERNAL"
+  region       = var.region[count.index]
+  timeouts {
+    create = "10m"
+  }
+}
+
+resource "google_compute_instance_template" "mariadb" {
+  count                = var.instance_count
+  project              = var.project_id
+  region               = var.region[count.index]
+  name                 = "mariadb-${var.cluster_name}-${count.index}-${var.template_version}"
+  description          = "MariaDB Instance Template"
+  instance_description = "MariaDB Server"
+  machine_type         = var.instance_type
+  can_ip_forward       = false
+  tags                 = ["mariadb", "internal"]
+  labels = {
+    template     = "tf-mariadb"
+    cluster_name = var.cluster_name
+  }
+  metadata = {
+    startup-script  = <<EOF
+#!/bin/bash
+gsutil cp gs://${var.bucket_name}/${var.cluster_name}/mariadb.sh /tmp/startup.sh
+nohup /bin/bash /tmp/startup.sh >/var/log/startup-script.log 2>&1 &
+EOF
+    node-id         = count.index
+    cluster-name    = var.cluster_name
+    cluster-members = "${google_compute_address.mariadb.*.address[0]},${google_compute_address.mariadb.*.address[1]},${google_compute_address.mariadb.*.address[2]},${google_compute_address.mariadb.*.address[3]}"
+    config-bucket   = var.bucket_name
+    databases       = var.databases
+    create-time     = var.create_time
+  }
+  disk {
+    source_image = var.vm_image
+    disk_size_gb = var.disk_size_gb
+    type         = var.disk_type
+  }
+  network_interface {
+    subnetwork         = var.subnetwork[count.index]
+    subnetwork_project = var.project_id
+    network_ip         = google_compute_address.mariadb.*.address[count.index]
+  }
+  service_account {
+    email  = "${var.service_account}@${var.project_id}.iam.gserviceaccount.com"
+    scopes = ["userinfo-email", "compute-ro", "storage-rw", "monitoring-write"]
+  }
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_instance_group_manager" "mariadb" {
+  count              = var.instance_count
+  provider           = "google-beta"
+  project            = var.project_id
+  name               = format("mariadb-${var.cluster_name}-%03d", count.index)
+  base_instance_name = format("mariadb-${var.cluster_name}-%03d", count.index)
+  zone               = var.zone[count.index]
+  target_size        = 1
+  version {
+    name              = "v1"
+    instance_template = google_compute_instance_template.mariadb.*.self_link[count.index]
+  }
+  update_policy {
+    minimal_action        = "REPLACE"
+    type                  = "OPPORTUNISTIC"
+    max_unavailable_fixed = "1"
+  }
+  auto_healing_policies {
+    health_check      = var.health_check_uri
+    initial_delay_sec = 300
+  }
+}
+
+resource "google_compute_instance_template" "garb" {
+  project              = var.project_id
+  region               = var.garb_region
+  name                 = "mariadb-${var.cluster_name}-garb-${var.template_version}"
+  description          = "MariaDB Galera Arbitrator Instance Template"
+  instance_description = "MariaDB Galera Arbitrator"
+  machine_type         = var.garb_instance_type
+  can_ip_forward       = false
+  tags                 = ["mariadb", "internal"]
+  labels = {
+    template     = "tf-mariadb"
+    cluster_name = var.cluster_name
+  }
+  metadata = {
+    startup-script  = <<EOF
+#!/bin/bash
+gsutil cp gs://${var.bucket_name}/${var.cluster_name}/garb.sh /tmp/startup.sh
+nohup /bin/bash /tmp/startup.sh >/var/log/startup-script.log 2>&1 &
+EOF
+    cluster-name    = var.cluster_name
+    node-id         = "garb"
+    config-bucket   = var.bucket_name
+    cluster-members = "${google_compute_address.mariadb.*.address[0]},${google_compute_address.mariadb.*.address[1]},${google_compute_address.mariadb.*.address[2]},${google_compute_address.mariadb.*.address[3]}"
+  }
+  disk {
+    source_image = var.vm_image
+    disk_size_gb = "32"
+    type         = "pd-standard"
+  }
+  network_interface {
+    subnetwork_project = var.project_id
+    subnetwork         = var.garb_subnetwork
+  }
+  service_account {
+    email  = "${var.service_account}@${var.project_id}.iam.gserviceaccount.com"
+    scopes = ["userinfo-email", "compute-ro", "storage-rw"]
+  }
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_instance_group_manager" "garb" {
+  provider           = "google-beta"
+  project            = var.project_id
+  name               = "mariadb-${var.cluster_name}-garb"
+  base_instance_name = "mariadb-${var.cluster_name}-garb"
+  zone               = var.garb_zone
+  target_size        = 1
+  version {
+    name              = "v1"
+    instance_template = google_compute_instance_template.garb.self_link
+  }
+  update_policy {
+    minimal_action        = "REPLACE"
+    type                  = "OPPORTUNISTIC"
+    max_unavailable_fixed = "1"
+  }
+}

--- a/modules/mariadb/objects.tf
+++ b/modules/mariadb/objects.tf
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+data "template_file" "mariadb" {
+  template = file("${path.module}/scripts/mariadb.sh.tpl")
+  vars = {
+    pass      = var.pass
+    replpass  = var.replpass
+    statspass = var.statspass
+  }
+}
+
+resource "google_storage_bucket_object" "mariadb" {
+  bucket  = var.bucket_name
+  name    = "${var.cluster_name}/mariadb.sh"
+  content = data.template_file.mariadb.rendered
+}
+
+resource "google_storage_bucket_object" "garb" {
+  bucket = var.bucket_name
+  name   = "${var.cluster_name}/garb.sh"
+  source = "${path.module}/scripts/garb.sh"
+}
+
+resource "google_storage_bucket_object" "ca" {
+  bucket  = var.bucket_name
+  name    = "${var.cluster_name}/ca.crt"
+  content = tls_self_signed_cert.ca.cert_pem
+}
+
+resource "google_storage_bucket_object" "garbcrt" {
+  bucket  = var.bucket_name
+  name    = "${var.cluster_name}/garb.crt"
+  content = tls_locally_signed_cert.crt.*.cert_pem[var.instance_count]
+}
+
+resource "google_storage_bucket_object" "garbkey" {
+  bucket  = var.bucket_name
+  name    = "${var.cluster_name}/garb.pem"
+  content = tls_private_key.key.*.private_key_pem[var.instance_count]
+}
+
+resource "google_storage_bucket_object" "crt" {
+  count   = var.instance_count
+  bucket  = var.bucket_name
+  name    = "${var.cluster_name}/${count.index}.crt"
+  content = tls_locally_signed_cert.crt.*.cert_pem[count.index]
+}
+
+resource "google_storage_bucket_object" "key" {
+  count   = var.instance_count
+  bucket  = var.bucket_name
+  name    = "${var.cluster_name}/${count.index}.pem"
+  content = tls_private_key.key.*.private_key_pem[count.index]
+}

--- a/modules/mariadb/scripts/garb.sh
+++ b/modules/mariadb/scripts/garb.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+
+METADATA_ROOT='http://metadata/computeMetadata/v1/instance/attributes'
+cluster_name=$(curl -f -s -H Metadata-Flavor:Google $METADATA_ROOT/cluster-name)
+cluster_members=$(curl -f -s -H Metadata-Flavor:Google $METADATA_ROOT/cluster-members)
+bucket_name=$(curl -f -s -H Metadata-Flavor:Google $METADATA_ROOT/config-bucket)
+gcs_root="gs://$bucket_name/$cluster_name"
+ssl_dir="/etc/mysql/ssl"
+log_dir="/var/log/garbd"
+
+# Install Galera Arbitrator
+export DEBIAN_FRONTEND=noninteractive
+apt update -y
+apt install -y software-properties-common dirmngr
+apt-key adv --recv-keys --no-tty --keyserver keyserver.ubuntu.com 0xF1656F24C74CD1D8
+add-apt-repository 'deb [arch=amd64,i386,ppc64el] http://sfo1.mirrors.digitalocean.com/mariadb/repo/10.3/debian stretch main'
+apt update -y
+apt install -y mariadb-client galera-3 galera-arbitrator-3
+
+service garb stop
+
+mkdir -p "$ssl_dir"
+gsutil cp "$gcs_root/garb.crt" "$ssl_dir/"
+gsutil cp "$gcs_root/garb.pem" "$ssl_dir/"
+gsutil cp "$gcs_root/ca.crt" "$ssl_dir/"
+chmod -R 744 "$ssl_dir"
+chmod 755 "$ssl_dir"
+mkdir -p "$log_dir"
+chmod 777 "$log_dir"
+
+cat <<EOF > /etc/default/garb
+GALERA_NODES="$cluster_members"
+LOG_FILE="$log_dir/garbd.log"
+GALERA_GROUP="$cluster_name"
+GALERA_OPTIONS="socket.ssl_cert=$ssl_dir/garb.crt;socket.ssl_key=$ssl_dir/garb.pem;socket.ssl_ca=$ssl_dir/ca.crt;socket.ssl_cipher=AES128-SHA256"
+EOF
+
+e=$(service garb start >/dev/null 2>&1; echo $?)
+let n=1
+while [ "$e" != "0" ]; do
+  sleep 30s
+  e=$(service garb start >/dev/null 2>&1; echo $?)
+  let n++
+  [ $n -le 10 ] || exit 1
+done
+
+cat <<EOF > /etc/logrotate.d/garbd
+/var/log/garbd/garbd*log {
+  weekly
+  rotate 150
+  dateext
+  compress
+  copytruncate
+  missingok 
+}
+EOF

--- a/modules/mariadb/scripts/mariadb.sh.tpl
+++ b/modules/mariadb/scripts/mariadb.sh.tpl
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+
+# Variables
+ip=`hostname -i`
+
+METADATA_ROOT='http://metadata/computeMetadata/v1/instance/attributes'
+id=$(curl -f -s -H Metadata-Flavor:Google $METADATA_ROOT/node-id)
+cluster_name=$(curl -f -s -H Metadata-Flavor:Google $METADATA_ROOT/cluster-name)
+bucket_name=$(curl -f -s -H Metadata-Flavor:Google $METADATA_ROOT/config-bucket)
+cluster_members=$(curl -f -s -H Metadata-Flavor:Google $METADATA_ROOT/cluster-members)
+databases=$(curl -f -s -H Metadata-Flavor:Google $METADATA_ROOT/databases)
+create_time=$(curl -f -s -H Metadata-Flavor:Google $METADATA_ROOT/create-time)
+
+gcs_root="gs://$bucket_name/$cluster_name"
+collectd_conf="/opt/stackdriver/collectd/etc/collectd.d/mysql.conf"
+ssl_dir="/etc/mysql/ssl"
+let offset=1+$id
+
+# Install MariaDB
+export DEBIAN_FRONTEND=noninteractive
+apt update -y
+apt install -y software-properties-common dirmngr
+apt-key adv --recv-keys --no-tty --keyserver keyserver.ubuntu.com 0xF1656F24C74CD1D8
+add-apt-repository 'deb [arch=amd64,i386,ppc64el] http://sfo1.mirrors.digitalocean.com/mariadb/repo/10.3/debian stretch main'
+apt update -y
+debconf-set-selections <<< 'mariadb-server-10.3 mysql-server/root_password password ${pass}'
+debconf-set-selections <<< 'mariadb-server-10.3 mysql-server/root_password_again password ${pass}'
+apt install -y mariadb-server mariadb-client galera-3
+
+service mysql stop
+
+cat <<EOF > /etc/mysql/mariadb.conf.d/galera.cnf
+[client]
+port     = 3306
+socket   = /var/run/mysqld/mysqld.sock
+ssl-ca   = $ssl_dir/ca.crt
+ssl-cert = $ssl_dir/$id.crt
+ssl-key  = $ssl_dir/$id.pem
+
+[mysql]
+default-character-set = utf8
+
+[mysqld]
+server_id                = $id
+report_host              = $id
+skip-networking          = 0
+skip-bind-address
+log_bin                  = /var/log/mysql/mariadb-bin
+log_bin_index            = /var/log/mysql/mariadb-bin.index
+relay_log                = /var/log/mysql/relay-bin
+relay_log_index          = /var/log/mysql/relay-bin.index
+collation-server         = utf8_general_ci
+character-set-server     = utf8
+binlog_format            = ROW
+default-storage-engine   = innodb
+innodb_autoinc_lock_mode = 2
+query_cache_size         = 0
+query_cache_type         = 0
+innodb_flush_log_at_trx_commit = 0
+innodb_buffer_pool_size  = 256M
+auto_increment_increment = 4
+auto_increment_offset    = $offset
+ssl-ca                   = $ssl_dir/ca.crt
+ssl-cert                 = $ssl_dir/$id.crt
+ssl-key                  = $ssl_dir/$id.pem
+wsrep_provider           = "/usr/lib/galera/libgalera_smm.so"
+wsrep_provider_options   ="socket.ssl_key=$ssl_dir/$id.pem;socket.ssl_cert=$ssl_dir/$id.crt;socket.ssl_ca=$ssl_dir/ca.crt;socket.ssl_cipher=AES128-SHA256"
+wsrep_cluster_name       = "$cluster_name"
+wsrep_cluster_address    = "gcomm://$cluster_members"
+wsrep_sst_method         = rsync
+wsrep_on                 = ON
+wsrep_node_address       = "$ip"
+wsrep_node_name          = "$id"
+explicit_defaults_for_timestamp = 1
+EOF
+
+mkdir -p "$ssl_dir"
+gsutil cp "$gcs_root/ca.crt" "$ssl_dir/"
+gsutil cp "$gcs_root/$id.crt" "$ssl_dir/"
+gsutil cp "$gcs_root/$id.pem" "$ssl_dir/"
+
+e=$(service mysql start >/dev/null 2>&1; echo $?)
+
+# Only bootstrap if cluster was created less than 15 minutes ago
+let bootstrap_period=$(date --date="$create_time" +%s)+900
+if [ $e -ne 0 ]; then
+  if [ $(date +%s) -lt $bootstrap_period ] && [ "$id" == "0" ]; then  
+    service mysql stop
+    systemctl set-environment _WSREP_NEW_CLUSTER='--wsrep-new-cluster'
+    service mysql start
+    systemctl set-environment _WSREP_NEW_CLUSTER=''
+    mysql -uroot -p${pass} -B <<EOF
+create user if not exists 'stats'@'localhost' identified by '${statspass}';
+grant select on sys.* to 'stats'@'localhost';
+grant select on performance_schema.* to 'stats'@'localhost';
+EOF
+    for db in $databases; do
+      mysql -uroot -p${pass} -B -e "create database if not exists $db;"
+    done
+  else
+    sleep 60s
+    service mysql start
+  fi
+fi
+
+mysql -uroot -p${pass} -N -B -e "show status like 'wsrep%';"
+
+# StackDriver Agent
+curl -sSO "https://dl.google.com/cloudagents/install-monitoring-agent.sh"
+/bin/bash install-monitoring-agent.sh
+apt install -y libmysqlclient20
+
+# Write collectd configuration
+cat <<EOF>> $collectd_conf
+LoadPlugin mysql
+<Plugin "mysql">
+EOF
+
+for db in $databases; do
+  cat <<EOF>> $collectd_conf
+    <Database "$db">
+        Host "localhost"
+        Port 3306
+        User "stats"
+        Password "${statspass}"
+        MasterStats true
+        SlaveStats true
+    </Database>
+EOF
+done
+
+cat <<EOF>> $collectd_conf
+</Plugin>
+EOF
+
+service stackdriver-agent restart

--- a/modules/mariadb/tls.tf
+++ b/modules/mariadb/tls.tf
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "tls_private_key" "ca" {
+  algorithm = "RSA"
+}
+
+resource "tls_private_key" "key" {
+  count     = var.instance_count + 1
+  algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "ca" {
+  key_algorithm         = "RSA"
+  private_key_pem       = tls_private_key.ca.private_key_pem
+  validity_period_hours = 87600
+  is_ca_certificate     = true
+  allowed_uses = [
+    "cert_signing",
+    "key_encipherment",
+    "digital_signature",
+  ]
+  subject {
+    country             = "US"
+    province            = "CA"
+    locality            = "Mountain View"
+    organization        = "Google"
+    organizational_unit = "Google Cloud Foundation Toolkit"
+    common_name         = "terraform"
+  }
+}
+
+resource "tls_cert_request" "csr" {
+  count           = var.instance_count + 1
+  key_algorithm   = "RSA"
+  private_key_pem = tls_private_key.key.*.private_key_pem[count.index]
+  subject {
+    country             = "US"
+    province            = "CA"
+    locality            = "Mountain View"
+    organization        = "Google"
+    organizational_unit = "Google Cloud Foundation Toolkit"
+    common_name         = count.index
+  }
+}
+
+resource "tls_locally_signed_cert" "crt" {
+  count                 = var.instance_count + 1
+  cert_request_pem      = tls_cert_request.csr.*.cert_request_pem[count.index]
+  ca_key_algorithm      = "RSA"
+  ca_private_key_pem    = tls_private_key.ca.private_key_pem
+  ca_cert_pem           = tls_self_signed_cert.ca.cert_pem
+  validity_period_hours = 43800
+  allowed_uses          = ["server_auth", "client_auth"]
+}

--- a/modules/mariadb/variables.tf
+++ b/modules/mariadb/variables.tf
@@ -1,0 +1,143 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The ID of the project in which to provision resources."
+  type        = string
+}
+
+variable "bucket_name" {
+  description = "The name of the bucket to create."
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "The name of the cluster, used in resource naming."
+  type        = string
+}
+
+variable "create_time" {
+  description = "Creation time formatted as 2018-01-02T23:12:01Z used to allow cluster bootstrap."
+  type        = string
+}
+
+variable "network_project" {
+  description = "The ID of the project containing the VPC network."
+  type        = string
+}
+
+variable "service_account" {
+  description = "The name of the service account to attach to VM instances."
+  type        = string
+}
+
+variable "instance_type" {
+  description = "The type of VM instance to use."
+  type        = string
+}
+
+variable "client_ip_range" {
+  description = "The IP range clients are allowed to connect from."
+  type        = string
+}
+
+variable "pass" {
+  description = "Password for mariadb root user."
+  type        = string
+}
+
+variable "replpass" {
+  description = "Password for mariadb repl user."
+  type        = string
+}
+
+variable "statspass" {
+  description = "Password for mariadb stats user."
+  type        = string
+}
+
+variable "instance_count" {
+  description = "Number of instances to create."
+  type        = number
+}
+
+variable "disk_size_gb" {
+  description = "Size of boot disk."
+  type        = number
+}
+
+variable "disk_type" {
+  description = "Type of boot disk."
+  type        = string
+}
+
+variable "health_check_uri" {
+  description = "URI of health check projects/*/global/healthChecks/*."
+  type        = string
+}
+
+variable "databases" {
+  description = "Space separated list of database names to be created."
+  type        = string
+}
+
+variable "vm_image" {
+  description = "VM Image to use in instance templates."
+  type        = string
+}
+
+variable "template_version" {
+  description = "Version string used in instance template naming."
+  type        = string
+}
+
+variable "garb_instance_type" {
+  description = "Instance type to be used for garb instance."
+  type        = string
+}
+
+variable "garb_zone" {
+  description = "Zone to be used for garb instance."
+  type        = string
+}
+
+variable "garb_region" {
+  description = "Region to be used for garb instance."
+  type        = string
+}
+
+variable "garb_subnetwork" {
+  description = "Subnetwork to be used for garb instance."
+  type        = string
+}
+
+
+# Map Variables with one record per instance
+variable "region" {
+  description = "List of instance regions."
+  type        = list(string)
+}
+
+variable "zone" {
+  description = "List of instance zones."
+  type        = list(string)
+}
+
+variable "subnetwork" {
+  description = "List of instance subnetwork names."
+  type        = list(string)
+}
+

--- a/modules/mariadb/versions.tf
+++ b/modules/mariadb/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,6 @@
  * limitations under the License.
  */
 
-provider "random" {
-  version = "~> 2.0"
-}
-
-resource "random_pet" "main" {
-  length    = 1
-  prefix    = "simple-example"
-  separator = "-"
-}
-
-module "example" {
-  source = "../../../examples/simple_example"
-
-  project_id  = var.project_id
-  bucket_name = random_pet.main.id
+terraform {
+  required_version = ">= 0.12"
 }

--- a/test/fixtures/mariadb/main.tf
+++ b/test/fixtures/mariadb/main.tf
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+provider "random" {
+  version = "~> 2.0"
+}
+
+resource "random_id" "id" {
+  byte_length = 4
+}
+
+locals {
+  id     = "cft-mariadb-${random_id.id.hex}"
+  region = "us-east1"
+  zone   = "us-east1-b"
+  subnet = google_compute_subnetwork.test.name
+}
+
+resource "google_compute_network" "test" {
+  project                 = var.project_id
+  name                    = local.id
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+  project                  = var.project_id
+  region                   = local.region
+  network                  = google_compute_network.test.self_link
+  name                     = local.id
+  ip_cidr_range            = "10.0.0.0/24"
+  private_ip_google_access = true
+}
+
+# NAT instance for test environment
+resource "google_compute_instance" "nat" {
+  project      = var.project_id
+  name         = "nat"
+  machine_type = "f1-micro"
+  zone         = local.zone
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    subnetwork_project = var.project_id
+    subnetwork         = local.subnet
+    access_config {}
+  }
+
+  metadata_startup_script = <<EOF
+#!/bin/bash
+sysctl -w net.ipv4.ip_forward=1
+iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+echo "net.ipv4.ip_forward=1" > /etc/sysctl.d/20-natgw.conf
+DEBIAN_FRONTEND=noninteractive apt install -y iptables-persistent
+EOF
+}
+
+# NAT Route
+resource "google_compute_route" "nat" {
+  project           = var.project_id
+  name              = "nat-route"
+  dest_range        = "0.0.0.0/0"
+  network           = google_compute_network.test.name
+  next_hop_instance = google_compute_instance.nat.self_link
+  tags              = ["internal"]
+  priority          = 100
+}
+
+module "example" {
+  source = "../../../examples/mariadb"
+
+  project_id   = var.project_id
+  bucket_name  = local.id
+  cluster_name = "cluster"
+  create_time  = timestamp()
+  databases    = "db"
+  region = [
+    local.region,
+    local.region,
+    local.region,
+    local.region,
+  ]
+  zone = [
+    local.zone,
+    local.zone,
+    local.zone,
+    local.zone,
+  ]
+  subnetwork = [
+    local.subnet,
+    local.subnet,
+    local.subnet,
+    local.subnet,
+  ]
+
+  /* It's necessary to pass a reference here
+   * otherwise terraform will not wait for the network to become ready
+   * and CI will fail with "resource is not ready"
+   */
+  network            = google_compute_network.test.name
+  network_project    = var.project_id
+  garb_region        = local.region
+  garb_zone          = local.zone
+  garb_subnetwork    = google_compute_subnetwork.test.name
+  garb_instance_type = "f1-micro"
+  health_check_name  = local.id
+  service_account    = local.id
+  instance_type      = "n1-standard-2"
+  disk_size_gb       = 32
+  disk_type          = "pd-standard"
+  client_ip_range    = "0.0.0.0/0"
+  pass               = local.id
+  statspass          = local.id
+  replpass           = local.id
+  instance_count     = 4
+  template_version   = "v1"
+}

--- a/test/fixtures/mariadb/outputs.tf
+++ b/test/fixtures/mariadb/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,5 +15,11 @@
  */
 
 output "bucket_name" {
-  value = google_storage_bucket.main.name
+  description = "The name of the bucket."
+  value       = module.example.bucket_name
+}
+
+output "project_id" {
+  description = "The ID of the project in which resources are provisioned."
+  value       = var.project_id
 }

--- a/test/fixtures/mariadb/variables.tf
+++ b/test/fixtures/mariadb/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,5 @@
 
 variable "project_id" {
   description = "The ID of the project in which to provision resources."
-  type        = string
-}
-
-variable "bucket_name" {
-  description = "The name of the bucket to create."
   type        = string
 }

--- a/test/fixtures/mariadb/versions.tf
+++ b/test/fixtures/mariadb/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/mariadb/controls/gcloud.rb
+++ b/test/integration/mariadb/controls/gcloud.rb
@@ -1,10 +1,10 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,12 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-control "gsutil" do
-  title "gsutil"
+control "gcloud" do
+  title "gcloud"
 
-  describe command("gsutil ls -p #{attribute("project_id")}") do
+  describe command("gcloud --project=#{attribute("project_id")} services list --enabled") do
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq "" }
-    its(:stdout) { should match "gs://#{attribute("bucket_name")}" }
+    its(:stdout) { should match "storage-api.googleapis.com" }
+  end
+
+  describe command("gcloud --project=#{attribute("project_id")} compute instances list | grep RUNNING | wc -l | awk {'print $1'}") do
+    its(:exit_status) { should eq 0 }
+    its(:stderr) { should eq "" }
+    its(:stdout) { should match "6" }
   end
 end

--- a/test/integration/mariadb/controls/gcp.rb
+++ b/test/integration/mariadb/controls/gcp.rb
@@ -1,10 +1,10 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/integration/mariadb/controls/gsutil.rb
+++ b/test/integration/mariadb/controls/gsutil.rb
@@ -1,10 +1,10 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-control "gcloud" do
-  title "gcloud"
+control "gsutil" do
+  title "gsutil"
 
-  describe command("gcloud --project=#{attribute("project_id")} services list --enabled") do
+  describe command("gsutil ls -p #{attribute("project_id")}") do
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq "" }
-    its(:stdout) { should match "storage-api.googleapis.com" }
+    its(:stdout) { should match "gs://#{attribute("bucket_name")}" }
   end
 end

--- a/test/integration/mariadb/inspec.yml
+++ b/test/integration/mariadb/inspec.yml
@@ -1,4 +1,4 @@
-name: simple_example
+name: mariadb
 depends:
   - name: inspec-gcp
     git: https://github.com/inspec/inspec-gcp.git

--- a/test/setup/make_source.sh
+++ b/test/setup/make_source.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR adds terraform modules used to MariaDB Galera Cluster with multi-master replication.
The default configuration deploys four MariaDB nodes and one Galera Arbitrator node.
Each node is deployed to its own Managed Instance Group.
A GCS bucket is used to store startup script and configuration files for each node.